### PR TITLE
Updated adj

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -47,7 +47,7 @@
   Graph.prototype.adj = function (u)
   {
     var adjacents = this._graph[u];
-    return typeof adjacents !== 'undefined' ? adjacents : {};
+    return adjacents ? adjacents : {};
   }
   
   Graph.prototype.get = function (u, v)

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -46,7 +46,8 @@
   
   Graph.prototype.adj = function (u)
   {
-    return this._graph[u];
+    var adjacents = this._graph[u];
+    return typeof adjacents !== 'undefined' ? adjacents : {};
   }
   
   Graph.prototype.get = function (u, v)

--- a/test/core.js
+++ b/test/core.js
@@ -230,6 +230,8 @@ this.core_suite =
   'Adjacency': function (test)
   {
     var g = new Graph();
+    test.ok(typeof g.adj(3) !== 'undefined',
+        "Should returns empty object when no adjacents.");
     g.set(1, 2);
     test.ok(1 in g.adj(2),
       "Vertex 1 is adjacent to vertex 2.");


### PR DESCRIPTION
Now returns empty `Object` on nonexisten adjacents.
