### PR TITLE
Fix small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Your graphs may have self edges, weighted edges, and directed edges, but not mul
 
     new Graph({
       a: ['b', 'c'],
-      c: ['d'],
+      c: ['b'],
     }); # triangle with vertices a, b, and c
     
     new Graph({


### PR DESCRIPTION
In the first example of 'Constructing Graphs with Data' it says:

new Graph({
  a: ['b', 'c'],
  c: ['d'],
}); # triangle with vertices a, b, and c

but the second line should be making an edge from 'c' to 'b' rather than 'c' to 'd'.
